### PR TITLE
Add ingest attachments plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Filter plugins to add ingest-attachment explicitly
+
 ## [1.0.0] - 2023-11-15
 
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2024-08-19
 
 ### Added
 - Filter plugins to add ingest-attachment explicitly

--- a/elasticpress-on-opensearch.php
+++ b/elasticpress-on-opensearch.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name:       ElasticPress on OpenSearch
  * Description:       Makes ElasticPress OpenSearch-compatible
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            dxw
  * Author URI:        https://dxw.com/
  */

--- a/elasticpress-on-opensearch.php
+++ b/elasticpress-on-opensearch.php
@@ -14,3 +14,13 @@ add_filter(
 		return '7.10';
 	}
 );
+
+add_filter(
+	'ep_elasticsearch_plugins',
+	function($info) {
+		if (!array_key_exists('ingest-attachment', $info)) {
+			$info['ingest-attachment'] = '2.13.0';
+		}
+		return $info;
+	}
+);


### PR DESCRIPTION
In practice we have found that Elasticpress shows an
error message complaining that the ingest-attachment
plugin is not available. However, this plugin is now
available on OpenSearch [1].

This commit filters the list of Elasticsearch plugins
to add ingest-attachment explicitly and suppress the
error.

See:
[1] https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html

## Testing

This can't easily be tested locally, it should be tested in a container on one of the new infrastructures (@leedxw).